### PR TITLE
Fix #30 — kube: wire up pods[*].namespace alias field and scope list pods by it

### DIFF
--- a/python/kube/executor.py
+++ b/python/kube/executor.py
@@ -165,7 +165,12 @@ class Kube:
             return
 
         default_id_pattern = config.data.get("pod_id_pattern", Constants.DEFAULT_POD_ID_PATTERN)
-        pods = active_scope_pods(config.data.get("pods", {}), active_scope)
+        scoped_pods = active_scope_pods(config.data.get("pods", {}), active_scope)
+        pods = {
+            alias: alias_config
+            for alias, alias_config in scoped_pods.items()
+            if alias_config.get("namespace") in (None, parsed["namespace"])
+        }
 
         if parsed.get("json"):
             payload = []

--- a/python/kube/executor.py
+++ b/python/kube/executor.py
@@ -239,6 +239,14 @@ class Kube:
             real_pod = pod_alias
         else:
             alias_config = scoped_pods[pod_alias]
+            pod_namespace = alias_config.get("namespace")
+            if pod_namespace and pod_namespace != parsed["namespace_alias"]:
+                print(
+                    f"kube shell: warning — pod alias '{pod_alias}' is configured for "
+                    f"namespace '{pod_namespace}', not '{parsed['namespace_alias']}' — "
+                    f"proceeding with '{parsed['namespace_alias']}'"
+                )
+
             default_id_pattern = config.data.get(
                 "pod_id_pattern", Constants.DEFAULT_POD_ID_PATTERN
             )

--- a/python/tests/kube/test_executor.py
+++ b/python/tests/kube/test_executor.py
@@ -240,6 +240,73 @@ def test_list_pods_groups_matched_pods_per_alias_in_deterministic_order(
     assert out.index("my-pod-aaaaaaaaaa") < out.index("my-pod-bbbbbbbbbb")
 
 
+@patch("kube.executor.detect_active_scope")
+@patch("kube.executor.list_pods")
+@patch("kube.executor.check_aws_credentials")
+def test_list_pods_filters_candidates_by_own_namespace_field(
+    mock_check, mock_list_pods, mock_detect, capsys
+):
+    mock_check.return_value = (True, None)
+    mock_detect.return_value = "prod"
+    mock_list_pods.return_value = (
+        [
+            _pod("app-aaaaaaaaaa", "2024-01-01T00:00:00Z"),
+            _pod("db-bbbbbbbbbb", "2024-01-01T00:00:00Z"),
+        ],
+        None,
+    )
+    config = _config(
+        namespaces={"prod": {"app": "prod-app-ns", "db": "prod-db-ns"}},
+        pods={
+            "prod": {
+                "app": {"prefix": "app-", "namespace": "app"},
+                "db": {"prefix": "db-", "namespace": "db"},
+            }
+        },
+        pod_id_pattern=r"^[a-z0-9]{10}$",
+    )
+
+    Kube._list_pods({"list_target": "pods", "namespace": "app"}, config)
+
+    mock_list_pods.assert_called_once_with("prod-app-ns")
+    out = capsys.readouterr().out
+    assert "app:" in out
+    assert "db:" not in out
+
+
+@patch("kube.executor.detect_active_scope")
+@patch("kube.executor.list_pods")
+@patch("kube.executor.check_aws_credentials")
+def test_list_pods_keeps_alias_without_namespace_field_regardless_of_request(
+    mock_check, mock_list_pods, mock_detect, capsys
+):
+    mock_check.return_value = (True, None)
+    mock_detect.return_value = "prod"
+    mock_list_pods.return_value = (
+        [
+            _pod("app-aaaaaaaaaa", "2024-01-01T00:00:00Z"),
+            _pod("shared-cccccccccc", "2024-01-01T00:00:00Z"),
+        ],
+        None,
+    )
+    config = _config(
+        namespaces={"prod": {"app": "prod-app-ns", "db": "prod-db-ns"}},
+        pods={
+            "prod": {
+                "app": {"prefix": "app-", "namespace": "app"},
+                "shared": {"prefix": "shared-"},
+            }
+        },
+        pod_id_pattern=r"^[a-z0-9]{10}$",
+    )
+
+    Kube._list_pods({"list_target": "pods", "namespace": "app"}, config)
+
+    out = capsys.readouterr().out
+    assert "app:" in out
+    assert "shared:" in out
+
+
 @patch("kube.executor.exec_shell")
 @patch("kube.executor.get_pod")
 @patch("kube.executor.list_pods")
@@ -293,6 +360,44 @@ def test_shell_single_match_resolves_and_execs(
     mock_exec.assert_called_once_with("prod-default-ns", "my-pod-aaaaaaaaaa", "bash")
     out = capsys.readouterr().out
     assert "warning" not in out.lower()
+
+
+@patch("kube.executor.exec_shell")
+@patch("kube.executor.get_pod")
+@patch("kube.executor.list_pods")
+@patch("kube.executor.detect_active_scope")
+@patch("kube.executor.check_aws_credentials")
+def test_shell_warns_when_pod_alias_namespace_conflicts_with_argument(
+    mock_check, mock_detect, mock_list_pods, mock_get_pod, mock_exec, capsys
+):
+    mock_check.return_value = (True, None)
+    mock_detect.return_value = "prod"
+    mock_list_pods.return_value = (
+        [_pod("app-aaaaaaaaaa", "2024-01-01T00:00:00Z")],
+        None,
+    )
+    mock_get_pod.return_value = ({"status": {"phase": "Running"}}, None)
+    mock_exec.return_value = (True, None)
+    config = _config(
+        namespaces={"prod": {"app": "prod-app-ns", "db": "prod-db-ns"}},
+        pods={
+            "prod": {
+                "app": {"prefix": "app-", "namespace": "app"},
+                "db": {"prefix": "db-", "namespace": "db"},
+            }
+        },
+        pod_id_pattern=r"^[a-z0-9]{10}$",
+        shell="bash",
+    )
+
+    Kube._shell({"namespace_alias": "db", "pod_alias": "app"}, config)
+
+    mock_list_pods.assert_called_once_with("prod-db-ns")
+    mock_exec.assert_called_once_with("prod-db-ns", "app-aaaaaaaaaa", "bash")
+    out = capsys.readouterr().out
+    assert "warning" in out.lower()
+    assert "app" in out
+    assert "db" in out
 
 
 @patch("kube.executor.exec_shell")


### PR DESCRIPTION
## Summary

Wires the previously-unused `pods[*][alias].namespace` config field into `tingle kube`'s resolution logic and scopes `list pods --namespace=<alias>` to only the pod aliases that actually belong to that namespace.

## Problem

An audit of `tingle kube` against the spec in #19 found the command surface, shell invocations, config schema/defaults, scoped alias resolution, pod-matching pipeline, and every Section 6 error behavior fully implemented and tested, but two real gaps remained around the `pods[*][alias].namespace` config field (spec §4.2):

1. `configure pod` writes a pod alias's `namespace` field, but nothing in `executor.py` ever reads it back — `shell`/`list pods` resolved the real namespace purely from the explicit CLI argument, ignoring the field.
2. `list pods --namespace=<alias>` iterated *every* pod alias in the active scope against the requested namespace, instead of only the ones whose own `namespace` field matches — so a scope with pod aliases spanning multiple namespaces (e.g. `app` and `db`) got cross-namespace false-positive matches.

## Solution

- `_list_pods` in `python/kube/executor.py` now filters `active_scope_pods` down to only aliases whose `namespace` field is unset or matches the requested `--namespace` alias, before running the prefix/id_pattern matching pipeline.
- `_shell` now checks the resolved pod alias's own `namespace` field against the `namespace_alias` argument the user typed. On a mismatch it warns (matching the existing "not Running" warning style) and proceeds using the explicit `namespace_alias` argument — it never hard-errors or silently ignores the mismatch.
- Added test coverage in `python/tests/kube/test_executor.py` for a scope with pod aliases spanning multiple namespaces (`app`/`db`), covering both `list pods` filtering and `shell`'s mismatch warning, plus the case where a pod alias has no `namespace` field set (unaffected, as before).

## Details

No config schema change — `namespace` already existed in the schema and was already written by `configure pod`; this only wires it into the read paths. `pod_id_pattern`/prefix matching itself (`matching.py`) is unaffected — only which pod aliases are considered, based on their namespace, changes.

Fixes #30
